### PR TITLE
Fix undefined incf for org-roam-extract-subtree

### DIFF
--- a/org-roam-node.el
+++ b/org-roam-node.el
@@ -837,7 +837,7 @@ Any top level properties drawers are incorporated into the new heading."
     (org-with-wide-buffer
      (org-map-region (lambda ()
                        (if (= (org-current-level) 1)
-                           (incf h1-count)))
+                           (cl-incf h1-count)))
                      (point-min) (point-max))
      h1-count)))
 


### PR DESCRIPTION
Calling org-roam-extract-subtree failes with "Symbol’s function definition is void: incf"

org-roam.el includes cl-lib. org-roam--h1-count uses a bare incf call, which is undefined. Fix this by using cl-incf.

###### Motivation for this change

org-roam-extract-subtree does not work, leaving you with the subtree already cut but an unsaved new buffer.